### PR TITLE
Enhance narrator tracking utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,36 @@
-To be built....
-# MelodramaGame
+# Melodrama Werewolf Narrator Tool
+
+This repository hosts a single-page web application that helps drama teachers run the classroom game **Melodrama Werewolf**. The app is designed to work on GitHub Pages (or any static host) and includes a full roster of characters, night/day narration prompts, a classroom-friendly timer, and note-taking utilities.
+
+## Features
+
+- Guided setup for 12–25 players with role cards grouped by dramatic type.
+- Auto-balancing badge that ensures the selected characters meet recommended good/evil and type counts.
+- Narrator dashboard with large-print script steps for the current phase, quick night/day reminders, and a persistent discussion timer.
+- Player management panel for tracking eliminations, protections, and private narrator notes.
+- Limited-use ability tracker that keeps count of one-off powers (Assassin, Right Hand, Voice, etc.) and surfaces remaining uses.
+- Night tracking summary that highlights current targets, protections, and eliminations with a one-click reset for the next round.
+- Sidekick dice roller with roll history and automatic success/fail labelling.
+- Downloadable notes export (including targets, protections, ability usage, and dice log) and offline support via a service worker.
+- Light/dark mode toggle and theme selector for flavourful narration variants.
+
+## Local Development
+
+Open the project in any modern browser:
+
+```bash
+# Serve locally (optional)
+npx serve .
+```
+
+Then navigate to `http://localhost:3000` (or the URL provided by your static server). The application is completely client-side; no build step is required.
+
+## Deployment
+
+1. Commit the latest changes to the main branch.
+2. Enable GitHub Pages for the repository (Settings → Pages → Deploy from a branch → `main` branch, `/ (root)` folder).
+3. Visit the published URL. The PWA manifest and service worker allow the narrator to continue using the tool offline once assets have loaded.
+
+## Acknowledgements
+
+Created as a teaching aid for the **Melodrama Werewolf: Year 7** drama unit. All artwork referenced in the design brief can be added later as static assets.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,1832 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Melodrama Werewolf Narrator</title>
+  <meta name="description" content="Digital narrator tool for the Melodrama Werewolf classroom drama game." />
+  <link rel="manifest" href="manifest.json" />
+  <meta name="theme-color" content="#0f172a" />
+  <style>
+    :root {
+      color-scheme: dark;
+      --bg-primary: #0f172a;
+      --bg-secondary: #1e293b;
+      --bg-tertiary: #334155;
+      --text-primary: #f8fafc;
+      --text-secondary: #cbd5e1;
+      --accent-good: #38bdf8;
+      --accent-evil: #f472b6;
+      --accent-neutral: #facc15;
+      --accent-ui: #22d3ee;
+      --border-color: #475569;
+      --panel-radius: 16px;
+      --shadow: 0 12px 30px rgba(15, 23, 42, 0.4);
+      font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    }
+
+    body.light {
+      color-scheme: light;
+      --bg-primary: #f1f5f9;
+      --bg-secondary: #ffffff;
+      --bg-tertiary: #e2e8f0;
+      --text-primary: #0f172a;
+      --text-secondary: #334155;
+      --border-color: #cbd5e1;
+      --shadow: 0 8px 22px rgba(15, 23, 42, 0.12);
+    }
+
+    * {
+      box-sizing: border-box;
+    }
+
+    body {
+      margin: 0;
+      background: radial-gradient(circle at top, rgba(56, 189, 248, 0.08), transparent 55%), var(--bg-primary);
+      color: var(--text-primary);
+      min-height: 100vh;
+      display: flex;
+      flex-direction: column;
+    }
+
+    header {
+      padding: 1rem clamp(1rem, 4vw, 3rem);
+      display: flex;
+      flex-wrap: wrap;
+      align-items: center;
+      justify-content: space-between;
+      gap: 1rem;
+    }
+
+    header h1 {
+      margin: 0;
+      font-size: clamp(1.8rem, 4vw, 2.6rem);
+      letter-spacing: 0.04em;
+    }
+
+    header h1 span {
+      color: var(--accent-evil);
+    }
+
+    header .actions {
+      display: flex;
+      gap: 0.75rem;
+      align-items: center;
+    }
+
+    button,
+    select,
+    input,
+    textarea {
+      font: inherit;
+      color: inherit;
+    }
+
+    button {
+      border: none;
+      padding: 0.65rem 1.1rem;
+      border-radius: 999px;
+      background: linear-gradient(135deg, rgba(56, 189, 248, 0.7), rgba(244, 114, 182, 0.9));
+      color: #0f172a;
+      font-weight: 600;
+      cursor: pointer;
+      transition: transform 120ms ease, box-shadow 120ms ease;
+      box-shadow: 0 8px 18px rgba(56, 189, 248, 0.25);
+    }
+
+    button:hover:not(:disabled) {
+      transform: translateY(-1px);
+      box-shadow: 0 12px 28px rgba(244, 114, 182, 0.28);
+    }
+
+    button:disabled {
+      opacity: 0.5;
+      cursor: not-allowed;
+    }
+
+    main {
+      flex: 1;
+      padding: 0 clamp(1rem, 4vw, 3rem) 4rem;
+      display: grid;
+      grid-template-columns: minmax(0, 1fr);
+      gap: 1.5rem;
+    }
+
+    section {
+      background: rgba(15, 23, 42, 0.55);
+      border: 1px solid rgba(148, 163, 184, 0.12);
+      border-radius: var(--panel-radius);
+      padding: clamp(1.25rem, 3vw, 2rem);
+      box-shadow: var(--shadow);
+      backdrop-filter: blur(18px);
+    }
+
+    body.light section {
+      background: rgba(255, 255, 255, 0.92);
+      border: 1px solid rgba(148, 163, 184, 0.25);
+    }
+
+    h2 {
+      margin-top: 0;
+      font-size: clamp(1.4rem, 3vw, 1.8rem);
+      letter-spacing: 0.02em;
+    }
+
+    .setup-grid {
+      display: grid;
+      gap: 1.25rem;
+      grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+    }
+
+    .stat {
+      background: rgba(15, 23, 42, 0.35);
+      padding: 0.75rem 1rem;
+      border-radius: 12px;
+      border: 1px solid rgba(148, 163, 184, 0.16);
+      display: flex;
+      flex-direction: column;
+      gap: 0.25rem;
+    }
+
+    .stat strong {
+      font-size: 1.8rem;
+      letter-spacing: 0.05em;
+    }
+
+    .range-input {
+      display: grid;
+      gap: 0.5rem;
+    }
+
+    input[type="range"] {
+      accent-color: var(--accent-evil);
+    }
+
+    .role-groups {
+      display: grid;
+      gap: 1rem;
+    }
+
+    .role-group {
+      border: 1px solid rgba(148, 163, 184, 0.16);
+      border-radius: 14px;
+      padding: 1rem;
+      background: rgba(15, 23, 42, 0.35);
+      display: grid;
+      gap: 0.75rem;
+    }
+
+    body.light .role-group {
+      background: rgba(255, 255, 255, 0.9);
+    }
+
+    .role-group-header {
+      display: flex;
+      justify-content: space-between;
+      align-items: baseline;
+      gap: 1rem;
+    }
+
+    .role-cards {
+      display: grid;
+      grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+      gap: 0.75rem;
+    }
+
+    .role-card {
+      border-radius: 18px;
+      padding: 1rem;
+      border: 2px solid transparent;
+      background: rgba(15, 23, 42, 0.45);
+      cursor: pointer;
+      transition: transform 120ms ease, border-color 120ms ease, background 120ms ease;
+      display: grid;
+      gap: 0.5rem;
+      position: relative;
+    }
+
+    body.light .role-card {
+      background: rgba(248, 250, 252, 0.88);
+    }
+
+    .role-card[data-selected="true"] {
+      transform: translateY(-3px);
+      border-color: var(--accent-ui);
+      box-shadow: 0 12px 22px rgba(34, 211, 238, 0.3);
+    }
+
+    .role-card .type {
+      font-size: 0.75rem;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      opacity: 0.75;
+    }
+
+    .role-card .team-label {
+      font-size: 0.8rem;
+      font-weight: 600;
+      display: inline-flex;
+      align-items: center;
+      gap: 0.4rem;
+    }
+
+    .badge {
+      display: inline-flex;
+      padding: 0.25rem 0.55rem;
+      border-radius: 999px;
+      font-size: 0.75rem;
+      font-weight: 600;
+      letter-spacing: 0.06em;
+      text-transform: uppercase;
+    }
+
+    .badge.good {
+      background: rgba(56, 189, 248, 0.2);
+      color: #bae6fd;
+    }
+
+    .badge.evil {
+      background: rgba(244, 114, 182, 0.2);
+      color: #fbcfe8;
+    }
+
+    .badge.neutral {
+      background: rgba(250, 204, 21, 0.2);
+      color: #fef08a;
+    }
+
+    body.light .badge.good {
+      color: #075985;
+    }
+
+    body.light .badge.evil {
+      color: #9d174d;
+    }
+
+    body.light .badge.neutral {
+      color: #b45309;
+    }
+
+    .role-card p {
+      font-size: 0.9rem;
+      margin: 0;
+      line-height: 1.4;
+      color: var(--text-secondary);
+    }
+
+    .role-card h3 {
+      margin: 0;
+      font-size: 1.05rem;
+      line-height: 1.3;
+    }
+
+    .card-ghost {
+      display: none;
+    }
+
+    .start-footer {
+      margin-top: 1.5rem;
+      display: flex;
+      flex-wrap: wrap;
+      gap: 1rem;
+      justify-content: space-between;
+      align-items: center;
+    }
+
+    .name-list {
+      width: 100%;
+      min-height: 120px;
+      padding: 0.75rem;
+      border-radius: 12px;
+      border: 1px solid rgba(148, 163, 184, 0.25);
+      background: rgba(15, 23, 42, 0.4);
+      resize: vertical;
+    }
+
+    body.light .name-list {
+      background: rgba(255, 255, 255, 0.95);
+    }
+
+    .hidden {
+      display: none !important;
+    }
+
+    .visually-hidden {
+      position: absolute !important;
+      width: 1px;
+      height: 1px;
+      padding: 0;
+      margin: -1px;
+      overflow: hidden;
+      clip: rect(0, 0, 0, 0);
+      border: 0;
+    }
+
+    .game-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+      gap: 1rem;
+    }
+
+    .script-panel {
+      display: grid;
+      gap: 1rem;
+    }
+
+    .script-step {
+      display: grid;
+      gap: 0.75rem;
+    }
+
+    .script-block {
+      padding: 0.85rem 1rem;
+      border-radius: 12px;
+      border: 1px solid rgba(148, 163, 184, 0.25);
+      background: rgba(15, 23, 42, 0.35);
+      line-height: 1.5;
+    }
+
+    .block-say {
+      border-left: 4px solid var(--accent-evil);
+      font-size: 1.15rem;
+      font-style: italic;
+    }
+
+    .block-narrator {
+      border-left: 4px solid var(--accent-ui);
+    }
+
+    .block-info {
+      border-left: 4px solid var(--accent-good);
+      color: var(--text-secondary);
+    }
+
+    .block-reminder {
+      border-left: 4px solid var(--accent-neutral);
+    }
+
+    .block-action {
+      border-left: 4px solid #f97316;
+    }
+
+    .script-nav {
+      display: flex;
+      gap: 0.75rem;
+      flex-wrap: wrap;
+    }
+
+    .script-nav button {
+      flex: 1;
+      min-width: 140px;
+    }
+
+    .status-panel,
+    .players-panel {
+      display: grid;
+      gap: 1rem;
+    }
+
+    .timer-card {
+      display: grid;
+      gap: 0.75rem;
+      padding: 1.5rem;
+      border-radius: 18px;
+      background: radial-gradient(circle at 25% 25%, rgba(56, 189, 248, 0.22), transparent), rgba(15, 23, 42, 0.45);
+      text-align: center;
+      border: 1px solid rgba(148, 163, 184, 0.22);
+    }
+
+    .timer-display {
+      font-size: clamp(2.4rem, 6vw, 3.4rem);
+      letter-spacing: 0.1em;
+    }
+
+    .timer-controls {
+      display: flex;
+      gap: 0.5rem;
+      flex-wrap: wrap;
+      justify-content: center;
+    }
+
+    .timer-controls button {
+      flex: 1 1 100px;
+    }
+
+    .pill {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      padding: 0.35rem 0.9rem;
+      border-radius: 999px;
+      background: rgba(15, 23, 42, 0.5);
+      border: 1px solid rgba(148, 163, 184, 0.22);
+      font-size: 0.85rem;
+      letter-spacing: 0.05em;
+      text-transform: uppercase;
+    }
+
+    .stat-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+      gap: 0.75rem;
+    }
+
+    .player-card {
+      border-radius: 16px;
+      padding: 1rem;
+      border: 1px solid rgba(148, 163, 184, 0.18);
+      background: rgba(15, 23, 42, 0.4);
+      display: grid;
+      gap: 0.5rem;
+    }
+
+    .player-card header {
+      display: flex;
+      justify-content: space-between;
+      align-items: baseline;
+      padding: 0;
+    }
+
+    .player-name {
+      font-weight: 600;
+      letter-spacing: 0.04em;
+    }
+
+    .player-meta {
+      font-size: 0.8rem;
+      color: var(--text-secondary);
+    }
+
+    .player-actions {
+      display: flex;
+      gap: 0.4rem;
+      flex-wrap: wrap;
+    }
+
+    .player-actions button {
+      background: rgba(148, 163, 184, 0.18);
+      color: var(--text-primary);
+      padding: 0.35rem 0.75rem;
+      border-radius: 8px;
+      flex: 1;
+      min-width: 90px;
+    }
+
+    .player-card[data-status="eliminated"] {
+      opacity: 0.55;
+      text-decoration: line-through;
+    }
+
+    .player-card[data-status="protected"] {
+      border-color: var(--accent-good);
+    }
+
+    .player-card[data-targeted="true"] {
+      border-color: #f97316;
+      box-shadow: 0 0 0 2px rgba(249, 115, 22, 0.35);
+    }
+
+    .player-card .uses-flag {
+      font-size: 0.75rem;
+      color: var(--text-secondary);
+      letter-spacing: 0.04em;
+      text-transform: uppercase;
+    }
+
+    .player-card[data-status="eliminated"] .player-actions button,
+    .player-card[data-status="eliminated"] textarea {
+      opacity: 0.6;
+    }
+
+    .player-card[data-status="eliminated"] .player-actions button {
+      pointer-events: none;
+    }
+
+    .ability-tracker,
+    .action-summary,
+    .dice-panel {
+      display: grid;
+      gap: 0.5rem;
+    }
+
+    .ability-row {
+      display: flex;
+      justify-content: space-between;
+      align-items: baseline;
+      padding: 0.35rem 0.5rem;
+      border-radius: 8px;
+      background: rgba(15, 23, 42, 0.35);
+      border: 1px solid rgba(148, 163, 184, 0.18);
+      font-size: 0.85rem;
+    }
+
+    .ability-row.is-eliminated {
+      opacity: 0.6;
+      text-decoration: line-through;
+    }
+
+    body.light .ability-row {
+      background: rgba(148, 163, 184, 0.18);
+    }
+
+    .ability-row strong {
+      font-weight: 600;
+      letter-spacing: 0.02em;
+    }
+
+    .ability-row span {
+      color: var(--text-secondary);
+    }
+
+    .action-summary ul,
+    .dice-panel ul {
+      margin: 0;
+      padding-left: 1.1rem;
+      display: grid;
+      gap: 0.3rem;
+      font-size: 0.9rem;
+    }
+
+    .action-summary p,
+    .dice-panel p {
+      margin: 0;
+      color: var(--text-secondary);
+      font-size: 0.9rem;
+    }
+
+    .action-summary button,
+    .dice-panel button {
+      justify-self: start;
+      background: rgba(148, 163, 184, 0.22);
+      color: var(--text-primary);
+    }
+
+    .dice-controls {
+      display: grid;
+      gap: 0.5rem;
+    }
+
+    .dice-result {
+      font-weight: 600;
+    }
+
+    .player-card textarea {
+      width: 100%;
+      min-height: 70px;
+      border-radius: 10px;
+      padding: 0.5rem;
+      background: rgba(15, 23, 42, 0.45);
+      border: 1px solid rgba(148, 163, 184, 0.25);
+      color: inherit;
+      resize: vertical;
+    }
+
+    @media (max-width: 768px) {
+      header {
+        flex-direction: column;
+        align-items: flex-start;
+      }
+
+      header .actions {
+        width: 100%;
+        justify-content: flex-start;
+      }
+
+      .role-cards {
+        grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
+      }
+
+      .player-actions button {
+        flex: 1 1 45%;
+      }
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>🎭 <span>Melodrama</span> Werewolf Narrator</h1>
+    <div class="actions">
+      <button id="toggle-mode" type="button" aria-pressed="false">Toggle Dark/Light</button>
+      <button id="reset-game" type="button">New Game</button>
+      <a id="download-notes" class="pill" href="#" download="melodrama-notes.txt">Export Notes</a>
+    </div>
+  </header>
+
+  <main>
+    <section id="setup-section">
+      <h2>Game Setup</h2>
+      <p>Build tonight's cast, assign names, and choose a theme. The tool will auto-balance good and evil roles and guide you through every beat of the drama.</p>
+
+      <div class="setup-grid">
+        <div class="stat">
+          <span>Total Players</span>
+          <strong id="player-count-display">18</strong>
+          <div class="range-input">
+            <input id="player-count" type="range" min="12" max="25" value="18" />
+            <div class="stat-grid" style="margin-top:0.5rem;">
+              <div>
+                <small>Suggested Good</small>
+                <div class="pill" id="suggested-good">12</div>
+              </div>
+              <div>
+                <small>Suggested Evil</small>
+                <div class="pill" id="suggested-evil">6</div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="stat">
+          <span>Theme</span>
+          <select id="theme-select" aria-label="Select narration theme"></select>
+          <small id="theme-description" style="color:var(--text-secondary);"></small>
+        </div>
+
+        <div class="stat">
+          <span>Player Names (optional)</span>
+          <textarea id="player-names" class="name-list" placeholder="Enter one name per line to assign specific students."></textarea>
+          <small style="color:var(--text-secondary);">Names are matched to roles when you start the game.</small>
+        </div>
+      </div>
+
+      <div class="role-groups" id="role-groups"></div>
+
+      <div class="start-footer">
+        <div>
+          <div class="pill" id="role-balance">Good: 0 • Evil: 0 • Selected: 0</div>
+          <small id="balance-warning" style="display:block; margin-top:0.4rem; color:#fef08a;">Select roles to match the player count.</small>
+        </div>
+        <button id="start-game" type="button" disabled>Enter Narrator View</button>
+      </div>
+    </section>
+
+    <section id="game-section" class="hidden">
+      <div class="game-grid">
+        <div class="script-panel" aria-live="polite">
+          <div>
+            <div class="pill" id="phase-label">Setup</div>
+            <h2 id="script-title">Narrator Script</h2>
+          </div>
+          <div id="script-steps" class="script-step"></div>
+          <div class="script-nav">
+            <button id="prev-step" type="button">Back</button>
+            <button id="next-step" type="button">Next</button>
+          </div>
+        </div>
+
+        <div class="status-panel">
+          <div class="timer-card" aria-live="polite">
+            <span class="pill" id="timer-phase">Timer</span>
+            <div class="timer-display" id="timer-display">03:00</div>
+            <div class="timer-controls">
+              <button data-timer="180" type="button">3 min</button>
+              <button data-timer="60" type="button">1 min</button>
+              <button id="start-timer" type="button">Start</button>
+              <button id="pause-timer" type="button">Pause</button>
+              <button id="reset-timer" type="button">Reset</button>
+            </div>
+          </div>
+          <div class="stat-grid">
+            <div class="stat">
+              <span>Night</span>
+              <strong id="night-number">1</strong>
+            </div>
+            <div class="stat">
+              <span>Alive</span>
+              <strong id="alive-count">0</strong>
+            </div>
+            <div class="stat">
+              <span>Team Split</span>
+              <div>Good: <strong id="good-count">0</strong></div>
+              <div>Evil: <strong id="evil-count">0</strong></div>
+            </div>
+          </div>
+          <div class="stat ability-tracker-card">
+            <span>Limited Abilities</span>
+            <div id="ability-tracker" class="ability-tracker">
+              <p>No limited-use abilities in play.</p>
+            </div>
+          </div>
+          <div class="stat action-summary-card">
+            <span>Tonight's Tracking</span>
+            <div id="action-summary" class="action-summary">
+              <p>No targets or protections recorded yet.</p>
+            </div>
+            <button id="clear-night-tracking" type="button">Clear Night Tracking</button>
+          </div>
+          <div class="stat dice-panel-card">
+            <span>Sidekick Dice Roller</span>
+            <div class="dice-panel">
+              <div class="dice-controls">
+                <label class="visually-hidden" for="dice-character">Select sidekick for dice roll</label>
+                <select id="dice-character"></select>
+                <button id="roll-dice" type="button">Roll d6</button>
+              </div>
+              <div id="dice-result" class="dice-result" aria-live="polite"></div>
+              <div>
+                <strong>History</strong>
+                <ul id="dice-history"></ul>
+              </div>
+            </div>
+          </div>
+          <div class="stat">
+            <span>Notes</span>
+            <textarea id="narrator-notes" class="name-list" placeholder="Quick reminders, dramatic twists, or classroom cues."></textarea>
+          </div>
+        </div>
+
+        <div class="players-panel">
+          <div class="pill">Players &amp; Roles</div>
+          <div id="player-list" class="player-list"></div>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <template id="player-card-template">
+    <article class="player-card" data-status="alive">
+      <header>
+        <div>
+          <div class="player-name"></div>
+          <div class="player-meta"></div>
+        </div>
+        <span class="badge"></span>
+      </header>
+      <p class="player-ability"></p>
+      <div class="player-actions"></div>
+      <textarea class="player-notes" placeholder="Add notes for this player"></textarea>
+    </article>
+  </template>
+
+  <script>
+    const CHARACTERS = [
+      { id: 1, name: "The Evil Mastermind", team: "evil", type: "villain", short: "Leads the villains, breaks ties.", nightOrder: 1 },
+      { id: 2, name: "The Assassin", team: "evil", type: "villain", short: "Once per game, add a second victim.", nightOrder: 1, limited: 1 },
+      { id: 3, name: "The Pretender", team: "evil", type: "villain", short: "Appears good to Elder checks.", nightOrder: 1 },
+      { id: 4, name: "Corrupted Authority", team: "evil", type: "villain", short: "Day vote counts as two.", nightOrder: 1 },
+      { id: 5, name: "The Stalker", team: "evil", type: "villain", short: "Backup elimination if target survives.", nightOrder: 1 },
+      { id: 6, name: "The Right Hand", team: "evil", type: "accomplice", short: "Block one player's night ability.", nightOrder: 2, limited: 1 },
+      { id: 7, name: "The Spy", team: "evil", type: "accomplice", short: "Learn if a player has a night action.", nightOrder: 2 },
+      { id: 8, name: "The Manipulator", team: "evil", type: "accomplice", short: "Silence one player's vote next day.", nightOrder: 2 },
+      { id: 9, name: "The Traitor", team: "evil", type: "accomplice", short: "Force revote if marked player is eliminated.", nightOrder: 2 },
+      { id: 10, name: "The Informant", team: "evil", type: "accomplice", short: "Reveal exact role of a player to evil team.", nightOrder: 2 },
+      { id: 11, name: "The Sage", team: "good", type: "elder", short: "Check two players; learn if at least one is evil.", nightOrder: 3 },
+      { id: 12, name: "The Oracle", team: "good", type: "elder", short: "Check one player; good or evil.", nightOrder: 3 },
+      { id: 13, name: "The Sensitive", team: "good", type: "elder", short: "Learn if a player has a night action.", nightOrder: 3 },
+      { id: 14, name: "The Dreamer", team: "good", type: "elder", short: "Learn how many evil sit beside them.", nightOrder: 3 },
+      { id: 15, name: "The Witness", team: "good", type: "elder", short: "Narrator gives a clue about the night.", nightOrder: 3 },
+      { id: 16, name: "The Champion", team: "good", type: "hero", short: "Protects nightly. First success reveals a villain but ends power.", nightOrder: 4 },
+      { id: 17, name: "The Healer", team: "good", type: "hero", short: "Save one player, can't repeat.", nightOrder: 4 },
+      { id: 18, name: "The Guardian", team: "good", type: "hero", short: "Sacrifice self to save another.", nightOrder: 4 },
+      { id: 19, name: "The Survivor", team: "good", type: "hero", short: "Survives first night attack until after next vote.", nightOrder: 4 },
+      { id: 20, name: "The Defender", team: "good", type: "hero", short: "Traps a player; if they die, a villain dies too.", nightOrder: 4 },
+      { id: 21, name: "The Loyal Companion", team: "good", type: "sidekick", short: "Knows Champion; can boost their vote (dice).", nightOrder: 5 },
+      { id: 22, name: "The Voice", team: "good", type: "sidekick", short: "Double elimination after vote (dice).", nightOrder: 5 },
+      { id: 23, name: "The Fool", team: "good", type: "sidekick", short: "Wild accusation with dramatic blowback (dice).", nightOrder: 5 },
+      { id: 24, name: "The Trickster", team: "good", type: "sidekick", short: "Creates a false claim (dice).", nightOrder: 5 },
+      { id: 25, name: "The Imitator", team: "good", type: "sidekick", short: "Copies another day power (dice).", nightOrder: 5 },
+      { id: 26, name: "The Marked", team: "good", type: "damsel", short: "If voted out, demand a dramatic revote.", nightOrder: 0 },
+      { id: 27, name: "The Innocent", team: "good", type: "damsel", short: "Can reveal once to confirm they are good.", nightOrder: 0 },
+      { id: 28, name: "Twin A", team: "good", type: "damsel", short: "Linked to Twin B. If one dies, both do.", nightOrder: 0 },
+      { id: 29, name: "Twin B", team: "good", type: "damsel", short: "Linked to Twin A. If one dies, both do.", nightOrder: 0 },
+      { id: 30, name: "The Cursed", team: "good", type: "damsel", short: "If eliminated, neighbors on both sides also fall.", nightOrder: 0 }
+    ];
+
+    const TYPE_DETAILS = {
+      villain: { label: "Villain-Type", min: 2, max: 5, description: "All wake together in Step 1 to pick the night's target.", accent: "var(--accent-evil)" },
+      accomplice: { label: "Accomplice-Type", min: 1, max: 5, description: "Thumbs-up helpers with one-off tricks to boost the villains.", accent: "#fb7185" },
+      elder: { label: "Elder-Type", min: 1, max: 5, description: "Information gatherers who never directly save or kill.", accent: "var(--accent-good)" },
+      hero: { label: "Hero-Type", min: 1, max: 5, description: "Defensive powers keeping the village alive.", accent: "#34d399" },
+      sidekick: { label: "Sidekick-Type", min: 1, max: 5, description: "Daytime drama with risky dice rolls.", accent: "#bef264" },
+      damsel: { label: "Damsel-Type", min: 1, max: 5, description: "Melodramatic twists when the crowd turns on them.", accent: "#a855f7" }
+    };
+
+    const THEMES = {
+      village: {
+        name: "Classic Village",
+        description: "Foggy streets, flickering lanterns, and suspicious glances.",
+        script: {
+          nightIntro: "Night descends over the village. Actors, close your eyes and fall into character...",
+          dayIntro: "The sun rises on the village square. Open your eyes and gasp dramatically!",
+          noDeaths: "Against all odds, everyone survived the night. Whisper relief... for now.",
+          deaths: victim => `Tragedy strikes! Last night we lost ${victim}. Prepare a spectacular exit.`,
+          vote: "The village must choose. On three, point boldly to your suspect!"
+        }
+      },
+      haunted: {
+        name: "Haunted Mansion",
+        description: "Thunder cracks, portraits watch, and secrets lurk in every corridor.",
+        script: {
+          nightIntro: "Storm clouds swallow the manor. Spirits, close your eyes...",
+          dayIntro: "Dawn forces its way in. Awake! Whose scream echoes today?",
+          noDeaths: "The mansion groaned but spared you. Celebrate in whispers.",
+          deaths: victim => `${victim} vanished into the walls overnight. Only echoes remain...",
+          vote: "Gather in the ballroom. At three, accuse with operatic flair!"
+        }
+      },
+      space: {
+        name: "Starship Melodrama",
+        description: "Red alerts, mysterious airlocks, and dramatic zero-g reveals.",
+        script: {
+          nightIntro: "Artificial night engages. Crew, helmets down and eyes closed...",
+          dayIntro: "Lights to full! Bridge crew, report your status with gusto!",
+          noDeaths: "Sensors show no casualties. Someone rerouted the danger...",
+          deaths: victim => `${victim} was jettisoned into the void. Cue the space dirge...",
+          vote: "Assemble in the hangar. At three, point to the saboteur!"
+        }
+      }
+    };
+
+    const PHASES = {
+      night: "Night Phase",
+      day: "Day Phase",
+      setup: "Setup"
+    };
+
+    const INITIAL_STATE = {
+      phase: "setup",
+      night: 1,
+      stepIndex: 0,
+      selectedRoles: [],
+      players: [],
+      theme: "village",
+      nameList: "",
+      notes: "",
+      mode: "dark",
+      diceHistory: [],
+      timer: {
+        remaining: 180,
+        running: false,
+        handle: null
+      }
+    };
+
+    let state = loadState();
+
+    const setupSection = document.getElementById("setup-section");
+    const gameSection = document.getElementById("game-section");
+    const playerCountInput = document.getElementById("player-count");
+    const playerCountDisplay = document.getElementById("player-count-display");
+    const suggestedGoodDisplay = document.getElementById("suggested-good");
+    const suggestedEvilDisplay = document.getElementById("suggested-evil");
+    const roleGroupsContainer = document.getElementById("role-groups");
+    const balanceBadge = document.getElementById("role-balance");
+    const balanceWarning = document.getElementById("balance-warning");
+    const startButton = document.getElementById("start-game");
+    const themeSelect = document.getElementById("theme-select");
+    const themeDescription = document.getElementById("theme-description");
+    const namesInput = document.getElementById("player-names");
+
+    const scriptStepsContainer = document.getElementById("script-steps");
+    const scriptTitle = document.getElementById("script-title");
+    const phaseLabel = document.getElementById("phase-label");
+    const prevStepButton = document.getElementById("prev-step");
+    const nextStepButton = document.getElementById("next-step");
+
+    const timerDisplay = document.getElementById("timer-display");
+    const timerButtons = document.querySelectorAll(".timer-controls button[data-timer]");
+    const startTimerBtn = document.getElementById("start-timer");
+    const pauseTimerBtn = document.getElementById("pause-timer");
+    const resetTimerBtn = document.getElementById("reset-timer");
+    const timerPhase = document.getElementById("timer-phase");
+
+    const nightNumber = document.getElementById("night-number");
+    const aliveCount = document.getElementById("alive-count");
+    const goodCount = document.getElementById("good-count");
+    const evilCount = document.getElementById("evil-count");
+
+    const playerList = document.getElementById("player-list");
+    const playerCardTemplate = document.getElementById("player-card-template");
+    const notesArea = document.getElementById("narrator-notes");
+
+    const abilityTracker = document.getElementById("ability-tracker");
+    const actionSummaryContainer = document.getElementById("action-summary");
+    const clearNightTrackingButton = document.getElementById("clear-night-tracking");
+    const diceCharacterSelect = document.getElementById("dice-character");
+    const rollDiceButton = document.getElementById("roll-dice");
+    const diceResult = document.getElementById("dice-result");
+    const diceHistoryList = document.getElementById("dice-history");
+
+    const toggleModeButton = document.getElementById("toggle-mode");
+    const resetGameButton = document.getElementById("reset-game");
+    const downloadNotesLink = document.getElementById("download-notes");
+
+    function applyMode(mode) {
+      document.body.classList.toggle("light", mode === "light");
+      toggleModeButton.setAttribute("aria-pressed", String(mode === "light"));
+    }
+
+    function hydratePlayers(list = []) {
+      return list.map((player, index) => {
+        const character = CHARACTERS.find(c => c.id === player.charId) || {};
+        const maxUses = typeof player.maxUses === "number"
+          ? player.maxUses
+          : typeof character.limited === "number"
+            ? character.limited
+            : null;
+        let usesRemaining = typeof player.usesRemaining === "number" ? player.usesRemaining : maxUses;
+        if (typeof usesRemaining === "number" && typeof maxUses === "number") {
+          usesRemaining = Math.max(0, Math.min(maxUses, usesRemaining));
+        } else {
+          usesRemaining = null;
+        }
+
+        return {
+          id: typeof player.id === "number" ? player.id : index,
+          charId: player.charId ?? character.id ?? null,
+          name: player.name ?? `Player ${index + 1}`,
+          roleName: player.roleName ?? character.name ?? "",
+          team: player.team ?? character.team ?? "good",
+          type: player.type ?? character.type ?? "villain",
+          ability: player.ability ?? character.short ?? "",
+          eliminated: Boolean(player.eliminated),
+          protected: Boolean(player.protected),
+          targeted: Boolean(player.targeted),
+          notes: player.notes ?? "",
+          maxUses,
+          usesRemaining,
+        };
+      });
+    }
+
+    function loadState() {
+      const stored = localStorage.getItem("melodrama-state-v1");
+      if (stored) {
+        try {
+          const parsed = JSON.parse(stored);
+          const base = structuredClone(INITIAL_STATE);
+          const merged = { ...base, ...parsed, timer: { ...base.timer, ...parsed.timer, handle: null } };
+          merged.players = hydratePlayers(parsed.players || merged.players);
+          merged.diceHistory = Array.isArray(parsed.diceHistory) ? parsed.diceHistory : [];
+          return merged;
+        } catch (error) {
+          console.warn("Failed to parse stored state", error);
+        }
+      }
+      return structuredClone(INITIAL_STATE);
+    }
+
+    function persistState() {
+      const toStore = { ...state, timer: { ...state.timer, handle: null } };
+      localStorage.setItem("melodrama-state-v1", JSON.stringify(toStore));
+    }
+
+    function resetState() {
+      state = structuredClone(INITIAL_STATE);
+      persistState();
+      if (downloadNotesLink.dataset.url) {
+        URL.revokeObjectURL(downloadNotesLink.dataset.url);
+        delete downloadNotesLink.dataset.url;
+      }
+      applyMode(state.mode);
+      renderAll();
+      setupSection.classList.remove("hidden");
+      gameSection.classList.add("hidden");
+    }
+
+    function renderThemeSelect() {
+      themeSelect.innerHTML = "";
+      Object.entries(THEMES).forEach(([key, info]) => {
+        const option = document.createElement("option");
+        option.value = key;
+        option.textContent = info.name;
+        themeSelect.append(option);
+      });
+      themeSelect.value = state.theme;
+      themeDescription.textContent = THEMES[state.theme].description;
+    }
+
+    function updatePlayerCountDisplays() {
+      const count = Number(playerCountInput.value);
+      playerCountDisplay.textContent = count;
+      const evil = Math.max(3, Math.round(count * 0.33));
+      const good = count - evil;
+      suggestedGoodDisplay.textContent = good;
+      suggestedEvilDisplay.textContent = evil;
+    }
+
+    function renderRoleGroups() {
+      const grouped = CHARACTERS.reduce((acc, char) => {
+        acc[char.type] ??= [];
+        acc[char.type].push(char);
+        return acc;
+      }, {});
+
+      roleGroupsContainer.innerHTML = "";
+      Object.entries(TYPE_DETAILS).forEach(([type, meta]) => {
+        const wrapper = document.createElement("div");
+        wrapper.className = "role-group";
+        wrapper.style.setProperty("--accent", meta.accent);
+
+        const header = document.createElement("div");
+        header.className = "role-group-header";
+        const title = document.createElement("div");
+        title.innerHTML = `<strong style="color:${meta.accent}">${meta.label}</strong><br><small>${meta.description}</small>`;
+        const rangeInfo = document.createElement("small");
+        rangeInfo.textContent = `Select ${meta.min} – ${meta.max}`;
+        header.append(title, rangeInfo);
+
+        const cards = document.createElement("div");
+        cards.className = "role-cards";
+        (grouped[type] || []).forEach(char => {
+          const card = document.createElement("article");
+          card.className = "role-card";
+          card.dataset.id = String(char.id);
+          card.dataset.team = char.team;
+          card.dataset.type = char.type;
+          card.innerHTML = `
+            <span class="type">${meta.label}</span>
+            <h3>${char.name}</h3>
+            <span class="team-label">
+              <span class="badge ${char.team}">${char.team.toUpperCase()}</span>
+              ${char.limited ? `• ${char.limited} use` : ""}
+            </span>
+            <p>${char.short}</p>
+          `;
+          card.addEventListener("click", () => toggleRoleSelection(char.id));
+          cards.append(card);
+        });
+
+        wrapper.append(header, cards);
+        roleGroupsContainer.append(wrapper);
+      });
+    }
+
+    function toggleRoleSelection(id) {
+      const selected = new Set(state.selectedRoles);
+      if (selected.has(id)) {
+        selected.delete(id);
+      } else {
+        selected.add(id);
+      }
+      state.selectedRoles = Array.from(selected);
+      updateRoleSelectionUI();
+      persistState();
+    }
+
+    function updateRoleSelectionUI() {
+      const cards = roleGroupsContainer.querySelectorAll(".role-card");
+      cards.forEach(card => {
+        card.dataset.selected = state.selectedRoles.includes(Number(card.dataset.id)) ? "true" : "false";
+      });
+      const totals = state.selectedRoles.reduce((acc, id) => {
+        const character = CHARACTERS.find(c => c.id === id);
+        if (!character) return acc;
+        acc.total += 1;
+        acc[character.team] += 1;
+        acc.byType[character.type] ??= 0;
+        acc.byType[character.type] += 1;
+        return acc;
+      }, { total: 0, good: 0, evil: 0, byType: {} });
+
+      balanceBadge.textContent = `Good: ${totals.good} • Evil: ${totals.evil} • Selected: ${totals.total}`;
+
+      const target = Number(playerCountInput.value);
+      const typeIssues = Object.entries(TYPE_DETAILS).filter(([type, info]) => {
+        const count = totals.byType[type] || 0;
+        return count < info.min || count > info.max;
+      });
+      const ready = totals.total === target && typeIssues.length === 0;
+      startButton.disabled = !ready;
+      balanceWarning.textContent = ready ? "Ready! Dramatic chaos awaits." : "Adjust counts to match the player total and type ranges.";
+    }
+
+    function preparePlayers() {
+      const selected = state.selectedRoles.map(id => CHARACTERS.find(c => c.id === id));
+      const names = state.nameList.split(/\n+/).map(n => n.trim()).filter(Boolean);
+      return selected.map((char, index) => ({
+        id: index,
+        charId: char.id,
+        name: names[index] || `Player ${index + 1}`,
+        roleName: char.name,
+        team: char.team,
+        type: char.type,
+        ability: char.short,
+        eliminated: false,
+        protected: false,
+        targeted: false,
+        maxUses: typeof char.limited === "number" ? char.limited : null,
+        usesRemaining: typeof char.limited === "number" ? char.limited : null,
+        notes: ""
+      }));
+    }
+
+    function buildScriptSteps() {
+      const theme = THEMES[state.theme];
+      const hasType = type => state.players.some(player => player.type === type);
+      const hasRole = id => state.players.some(player => player.charId === id);
+
+      const nightSteps = [];
+      if (state.night === 1) {
+        nightSteps.push({
+          title: "Night 1 Opening",
+          phase: "night",
+          blocks: [
+            { type: "say", text: theme.script.nightIntro },
+            { type: "narrator", text: "Remind students: silent acting only. Encourage over-the-top reactions when woken." }
+          ]
+        });
+        if (hasType("accomplice")) {
+          nightSteps.push({
+            title: "Night 1: Accomplices Meet Villains",
+            phase: "night",
+            blocks: [
+              { type: "say", text: "Accomplices, lift your heads and find your villain allies." },
+              { type: "narrator", text: "Have villains give a subtle nod so accomplices know them." }
+            ]
+          });
+        }
+        if (hasRole(16)) {
+          nightSteps.push({
+            title: "Night 1: Champion Sees the Cursed",
+            phase: "night",
+            blocks: [
+              { type: "say", text: "Champion, open your eyes and look for the Cursed." },
+              { type: "narrator", text: "Point silently to the Cursed player's seat." }
+            ]
+          });
+        }
+        if (hasRole(28) && hasRole(29)) {
+          nightSteps.push({
+            title: "Night 1: Twins Meet",
+            phase: "night",
+            blocks: [
+              { type: "say", text: "Twin A and Twin B, open your eyes and find each other." },
+              { type: "narrator", text: "Remind them: if one is eliminated, the other falls immediately." }
+            ]
+          });
+        }
+        if (hasRole(21)) {
+          nightSteps.push({
+            title: "Night 1: Loyal Companion",
+            phase: "night",
+            blocks: [
+              { type: "say", text: "Loyal Companion, open your eyes. Champion, give them a nod." },
+              { type: "narrator", text: "Confirm they've spotted each other before sending them back to sleep." }
+            ]
+          });
+        }
+      } else {
+        nightSteps.push({
+          title: `Night ${state.night} Begins`,
+          phase: "night",
+          blocks: [
+            { type: "say", text: theme.script.nightIntro },
+            { type: "reminder", text: "Encourage players to hunch, clutch pearls, or otherwise act the part." }
+          ]
+        });
+      }
+
+      if (hasType("villain")) {
+        const villains = state.players.filter(p => p.type === "villain" && !p.eliminated).map(p => `${p.name} (${p.roleName})`).join(", ");
+        nightSteps.push({
+          title: "Step 1: Villain-Type",
+          phase: "night",
+          blocks: [
+            { type: "say", text: "Villain team, open your eyes and choose your victim." },
+            { type: "narrator", text: "Watch their silent debate. Confirm their choice before moving on." },
+            { type: "info", text: `Villains alive: ${villains || "None"}` }
+          ]
+        });
+      }
+
+      if (hasType("accomplice")) {
+        nightSteps.push({
+          title: "Step 2: Accomplice-Type",
+          phase: "night",
+          blocks: [
+            { type: "say", text: "Accomplices with abilities remaining, give a subtle thumbs-up." },
+            { type: "narrator", text: "If a thumb is raised, quietly confirm which ability they're using tonight." }
+          ]
+        });
+      }
+
+      if (hasType("elder")) {
+        nightSteps.push({
+          title: "Step 3: Elder-Type",
+          phase: "night",
+          blocks: [
+            { type: "say", text: "Elders, one at a time, open your eyes when your title is called." },
+            { type: "narrator", text: "Whisper their options and hold up fingers for results." }
+          ]
+        });
+      }
+
+      if (hasType("hero")) {
+        nightSteps.push({
+          title: "Step 4: Hero-Type",
+          phase: "night",
+          blocks: [
+            { type: "say", text: "Heroes, when called, lift your head and select your target." },
+            { type: "reminder", text: "Track who was protected last night so they don't repeat illegal saves." }
+          ]
+        });
+      }
+
+      if (hasType("sidekick")) {
+        nightSteps.push({
+          title: "Step 5: Sidekick-Type",
+          phase: "night",
+          blocks: [
+            { type: "say", text: "Sidekicks ready for drama, give a single silent thumbs-up." },
+            { type: "narrator", text: "Note who will trigger a dice roll during the day phase." }
+          ]
+        });
+      }
+
+      nightSteps.push({
+        title: "Night Resolution",
+        phase: "night",
+        blocks: [
+          { type: "narrator", text: "Work through any protections or clashes. Once resolved, prepare the morning reveal." }
+        ]
+      });
+
+      const daySteps = [
+        {
+          title: `Day ${state.night} Dawn`,
+          phase: "day",
+          blocks: [
+            { type: "say", text: theme.script.dayIntro },
+            { type: "info", text: "Let eliminated players deliver a 3–5 second death scene before sitting out." }
+          ]
+        },
+        {
+          title: "Announcements",
+          phase: "day",
+          blocks: [
+            { type: "say", text: "Narrate last night's events with flair. Announce who (if anyone) was eliminated." },
+            { type: "reminder", text: "If the Innocent reveals today, confirm their goodness immediately." }
+          ]
+        },
+        {
+          title: "Discussion",
+          phase: "day",
+          blocks: [
+            { type: "say", text: "The floor is yours! Accuse with melodrama. Timer is set to three minutes." },
+            { type: "action", text: "Start the timer below when the debate begins." }
+          ]
+        },
+        {
+          title: "Voting",
+          phase: "day",
+          blocks: [
+            { type: "say", text: theme.script.vote },
+            { type: "reminder", text: "Repeat Corrupted Authority's vote twice if they're alive." }
+          ]
+        },
+        {
+          title: "Resolution",
+          phase: "day",
+          blocks: [
+            { type: "narrator", text: "Record who is eliminated. Apply any dramatic twists (Marked revote, Twins, Cursed)." }
+          ]
+        }
+      ];
+
+      return [...nightSteps, ...daySteps];
+    }
+
+    function renderScript() {
+      const steps = buildScriptSteps();
+      const step = steps[state.stepIndex];
+      scriptStepsContainer.innerHTML = "";
+      if (!step) {
+        scriptTitle.textContent = "End of Phase";
+        phaseLabel.textContent = "Summary";
+        scriptStepsContainer.innerHTML = "<p>All steps complete. Advance when ready for the next night.";
+      } else {
+        scriptTitle.textContent = step.title;
+        phaseLabel.textContent = PHASES[step.phase] || "Script";
+        step.blocks.forEach(block => {
+          const div = document.createElement("div");
+          div.className = `script-block block-${block.type}`;
+          div.textContent = block.text;
+          scriptStepsContainer.append(div);
+        });
+      }
+
+      prevStepButton.disabled = state.stepIndex === 0;
+      nextStepButton.textContent = state.stepIndex >= steps.length - 1 ? "Next Night" : "Next";
+
+      const discussionIndex = steps.findIndex(step => step.title === "Discussion");
+      if (discussionIndex >= 0 && state.stepIndex >= discussionIndex) {
+        timerPhase.textContent = "Discussion Timer";
+      } else {
+        timerPhase.textContent = "Timer";
+      }
+    }
+
+    function renderPlayers() {
+      playerList.innerHTML = "";
+      state.players.forEach(player => {
+        const clone = playerCardTemplate.content.cloneNode(true);
+        const card = clone.querySelector(".player-card");
+        card.dataset.status = player.eliminated ? "eliminated" : player.protected ? "protected" : "alive";
+        card.dataset.targeted = player.targeted ? "true" : "false";
+        card.dataset.id = player.id;
+        clone.querySelector(".player-name").textContent = player.name;
+        clone.querySelector(".player-meta").textContent = `${player.roleName} • ${TYPE_DETAILS[player.type].label}`;
+        const badge = clone.querySelector(".badge");
+        badge.classList.add(player.team);
+        badge.textContent = player.team.toUpperCase();
+        const abilityText = clone.querySelector(".player-ability");
+        abilityText.textContent = player.ability;
+        if (typeof player.maxUses === "number") {
+          abilityText.append(document.createElement("br"));
+          const flag = document.createElement("span");
+          flag.className = "uses-flag";
+          flag.textContent = `Uses left: ${player.usesRemaining}/${player.maxUses}`;
+          abilityText.append(flag);
+        }
+        const actionsContainer = clone.querySelector(".player-actions");
+        actionsContainer.innerHTML = "";
+        const actions = [
+          {
+            action: "toggle-eliminated",
+            label: player.eliminated ? "Mark Alive" : "Mark Eliminated",
+          },
+          {
+            action: "toggle-protected",
+            label: player.protected ? "Clear Protection" : "Mark Protected",
+          },
+          {
+            action: "toggle-targeted",
+            label: player.targeted ? "Clear Target" : "Mark Target",
+          },
+        ];
+        if (typeof player.maxUses === "number") {
+          actions.push({
+            action: "use-ability",
+            label: player.usesRemaining > 0 ? `Use Power (${player.usesRemaining})` : "No Uses Left",
+            disabled: player.usesRemaining === 0,
+          });
+          actions.push({
+            action: "refund-ability",
+            label: "Refund Use",
+            disabled: player.usesRemaining >= player.maxUses,
+          });
+        }
+        actions.forEach(({ action, label, disabled }) => {
+          const button = document.createElement("button");
+          button.type = "button";
+          button.dataset.action = action;
+          button.textContent = label;
+          if (disabled) {
+            button.disabled = true;
+          }
+          button.addEventListener("click", () => handlePlayerAction(player.id, action));
+          actionsContainer.append(button);
+        });
+        const notes = clone.querySelector(".player-notes");
+        notes.value = player.notes;
+        notes.addEventListener("input", (event) => {
+          player.notes = event.target.value;
+          persistState();
+        });
+        playerList.append(clone);
+      });
+    }
+
+    function renderAbilityTracker() {
+      abilityTracker.innerHTML = "";
+      const limited = state.players.filter(player => typeof player.maxUses === "number");
+      if (!limited.length) {
+        const message = document.createElement("p");
+        message.textContent = "No limited-use abilities in play.";
+        abilityTracker.append(message);
+        return;
+      }
+
+      limited.forEach(player => {
+        const row = document.createElement("div");
+        row.className = "ability-row";
+        if (player.eliminated) row.classList.add("is-eliminated");
+        const name = document.createElement("strong");
+        name.textContent = player.name;
+        const role = document.createElement("span");
+        role.textContent = player.roleName;
+        const uses = document.createElement("span");
+        uses.textContent = `${player.usesRemaining ?? 0}/${player.maxUses} left`;
+        row.append(name, role, uses);
+        abilityTracker.append(row);
+      });
+    }
+
+    function renderActionSummary() {
+      actionSummaryContainer.innerHTML = "";
+      const targeted = state.players.filter(player => player.targeted);
+      const protectedPlayers = state.players.filter(player => player.protected);
+      const eliminated = state.players.filter(player => player.eliminated);
+
+      if (!targeted.length && !protectedPlayers.length && !eliminated.length) {
+        const message = document.createElement("p");
+        message.textContent = "No targets or protections recorded yet.";
+        actionSummaryContainer.append(message);
+        return;
+      }
+
+      if (targeted.length) {
+        const heading = document.createElement("strong");
+        heading.textContent = "Targets";
+        const list = document.createElement("ul");
+        targeted.forEach(player => {
+          const item = document.createElement("li");
+          item.textContent = `${player.name} (${player.roleName})`;
+          list.append(item);
+        });
+        actionSummaryContainer.append(heading, list);
+      }
+
+      if (protectedPlayers.length) {
+        const heading = document.createElement("strong");
+        heading.textContent = "Protections";
+        const list = document.createElement("ul");
+        protectedPlayers.forEach(player => {
+          const item = document.createElement("li");
+          item.textContent = `${player.name} (${player.roleName})`;
+          list.append(item);
+        });
+        actionSummaryContainer.append(heading, list);
+      }
+
+      if (eliminated.length) {
+        const heading = document.createElement("strong");
+        heading.textContent = "Eliminated";
+        const list = document.createElement("ul");
+        eliminated.forEach(player => {
+          const item = document.createElement("li");
+          item.textContent = `${player.name} (${player.roleName})`;
+          list.append(item);
+        });
+        actionSummaryContainer.append(heading, list);
+      }
+    }
+
+    function renderDiceOptions() {
+      diceCharacterSelect.innerHTML = "";
+      const placeholder = document.createElement("option");
+      placeholder.value = "";
+      placeholder.textContent = "Select sidekick in play";
+      diceCharacterSelect.append(placeholder);
+
+      const sidekicks = state.players.filter(player => player.type === "sidekick");
+      sidekicks.forEach(player => {
+        const option = document.createElement("option");
+        option.value = String(player.id);
+        option.textContent = `${player.name} – ${player.roleName}${player.eliminated ? " (eliminated)" : ""}`;
+        if (player.eliminated) option.disabled = true;
+        diceCharacterSelect.append(option);
+      });
+
+      const custom = document.createElement("option");
+      custom.value = "custom";
+      custom.textContent = "Custom / practice roll";
+      diceCharacterSelect.append(custom);
+    }
+
+    function renderDiceHistory() {
+      diceHistoryList.innerHTML = "";
+      if (!state.diceHistory.length) {
+        const empty = document.createElement("li");
+        empty.textContent = "No rolls yet.";
+        diceHistoryList.append(empty);
+        diceResult.textContent = "";
+        return;
+      }
+
+      const latest = state.diceHistory[0];
+      diceResult.textContent = `Night ${latest.night}: rolled ${latest.result} – ${latest.success ? "SUCCESS" : "FAIL"}`;
+
+      state.diceHistory.slice(0, 6).forEach(entry => {
+        const player = state.players.find(p => p.id === entry.playerId);
+        const label = player
+          ? `${player.name} (${player.roleName})`
+          : entry.playerName ?? "Unknown";
+        const item = document.createElement("li");
+        item.textContent = `Night ${entry.night}: ${label} rolled ${entry.result} – ${entry.success ? "success" : "fail"}`;
+        diceHistoryList.append(item);
+      });
+    }
+
+    function handlePlayerAction(id, action) {
+      const player = state.players.find(p => p.id === id);
+      if (!player) return;
+      if (action === "toggle-eliminated") {
+        player.eliminated = !player.eliminated;
+        if (player.eliminated) {
+          player.protected = false;
+          player.targeted = false;
+        }
+      }
+      if (action === "toggle-protected") {
+        player.protected = !player.protected;
+        if (player.protected) player.eliminated = false;
+      }
+      if (action === "toggle-targeted") {
+        player.targeted = !player.targeted;
+      }
+      if (action === "use-ability" && typeof player.usesRemaining === "number") {
+        if (player.usesRemaining > 0) {
+          player.usesRemaining -= 1;
+        }
+      }
+      if (action === "refund-ability" && typeof player.usesRemaining === "number" && typeof player.maxUses === "number") {
+        if (player.usesRemaining < player.maxUses) {
+          player.usesRemaining += 1;
+        }
+      }
+      updateCounts();
+      renderPlayers();
+      renderAbilityTracker();
+      renderActionSummary();
+      renderDiceOptions();
+      persistState();
+      renderDownloadLink();
+      clearNightTrackingButton.disabled = !state.players.some(player => player.targeted || player.protected);
+    }
+
+    function updateCounts() {
+      const alivePlayers = state.players.filter(p => !p.eliminated);
+      aliveCount.textContent = alivePlayers.length;
+      goodCount.textContent = alivePlayers.filter(p => p.team === "good").length;
+      evilCount.textContent = alivePlayers.filter(p => p.team === "evil").length;
+      nightNumber.textContent = state.night;
+    }
+
+    function goToNextStep() {
+      const steps = buildScriptSteps();
+      state.stepIndex = Math.min(state.stepIndex + 1, steps.length);
+      let advancedNight = false;
+      if (state.stepIndex >= steps.length) {
+        state.night += 1;
+        state.stepIndex = 0;
+        advancedNight = true;
+        state.players.forEach(player => {
+          player.targeted = false;
+        });
+      }
+      persistState();
+      renderScript();
+      if (advancedNight) {
+        updateCounts();
+      }
+      renderPlayers();
+      renderAbilityTracker();
+      renderActionSummary();
+      renderDiceOptions();
+      renderDiceHistory();
+      renderDownloadLink();
+      clearNightTrackingButton.disabled = !state.players.some(player => player.targeted || player.protected);
+    }
+
+    function goToPrevStep() {
+      state.stepIndex = Math.max(0, state.stepIndex - 1);
+      persistState();
+      renderScript();
+      renderPlayers();
+      renderAbilityTracker();
+      renderActionSummary();
+      renderDiceOptions();
+      renderDiceHistory();
+      renderDownloadLink();
+      clearNightTrackingButton.disabled = !state.players.some(player => player.targeted || player.protected);
+    }
+
+    function renderTimer() {
+      const minutes = String(Math.floor(state.timer.remaining / 60)).padStart(2, "0");
+      const seconds = String(state.timer.remaining % 60).padStart(2, "0");
+      timerDisplay.textContent = `${minutes}:${seconds}`;
+    }
+
+    function startTimer(duration) {
+      if (typeof duration === "number") {
+        state.timer.remaining = duration;
+      }
+      if (state.timer.handle) {
+        clearInterval(state.timer.handle);
+      }
+      state.timer.running = true;
+      state.timer.handle = setInterval(() => {
+        if (state.timer.remaining > 0) {
+          state.timer.remaining -= 1;
+          renderTimer();
+          if (state.timer.remaining === 0) {
+            alert("Timer complete! Time for a dramatic decision.");
+          }
+        }
+      }, 1000);
+      persistState();
+    }
+
+    function pauseTimer() {
+      state.timer.running = false;
+      if (state.timer.handle) clearInterval(state.timer.handle);
+      state.timer.handle = null;
+      persistState();
+    }
+
+    function resetTimer() {
+      pauseTimer();
+      state.timer.remaining = 180;
+      renderTimer();
+      persistState();
+    }
+
+    function handleStartGame() {
+      state.players = preparePlayers();
+      state.phase = "night";
+      state.night = 1;
+      state.stepIndex = 0;
+      state.notes = notesArea.value;
+      state.diceHistory = [];
+      persistState();
+      setupSection.classList.add("hidden");
+      gameSection.classList.remove("hidden");
+      renderAll();
+    }
+
+    function renderDownloadLink() {
+      const notes = [`Narrator Notes - Night ${state.night}`, "==============================", "", notesArea.value || "(none)", "", "Player Notes:"];
+      state.players.forEach(player => {
+        const status = player.eliminated ? "Eliminated" : "Alive";
+        notes.push(`${player.name} - ${player.roleName} (${status})`);
+        if (player.notes) notes.push(`  Notes: ${player.notes}`);
+      });
+      const targets = state.players.filter(player => player.targeted);
+      if (targets.length) {
+        notes.push("", "Night Targets:");
+        targets.forEach(player => notes.push(`- ${player.name} (${player.roleName})`));
+      }
+      const protections = state.players.filter(player => player.protected);
+      if (protections.length) {
+        notes.push("", "Protections:");
+        protections.forEach(player => notes.push(`- ${player.name} (${player.roleName})`));
+      }
+      const limited = state.players.filter(player => typeof player.maxUses === "number");
+      if (limited.length) {
+        notes.push("", "Limited Abilities:");
+        limited.forEach(player => notes.push(`- ${player.name}: ${player.usesRemaining ?? 0}/${player.maxUses} uses remaining`));
+      }
+      if (state.diceHistory.length) {
+        notes.push("", "Dice History:");
+        state.diceHistory.forEach(entry => {
+          const label = entry.playerName || "Unknown";
+          const role = entry.roleName ? ` (${entry.roleName})` : "";
+          notes.push(`- Night ${entry.night}: ${label}${role} rolled ${entry.result} – ${entry.success ? "success" : "fail"}`);
+        });
+      }
+      const blob = new Blob([notes.join("\n")], { type: "text/plain" });
+      if (downloadNotesLink.dataset.url) {
+        URL.revokeObjectURL(downloadNotesLink.dataset.url);
+      }
+      const objectUrl = URL.createObjectURL(blob);
+      downloadNotesLink.href = objectUrl;
+      downloadNotesLink.dataset.url = objectUrl;
+    }
+
+    function renderAll() {
+      applyMode(state.mode);
+      updatePlayerCountDisplays();
+      updateRoleSelectionUI();
+      renderThemeSelect();
+      renderTimer();
+      namesInput.value = state.nameList;
+      if (state.phase === "setup") {
+        setupSection.classList.remove("hidden");
+        gameSection.classList.add("hidden");
+        playerList.innerHTML = "";
+        diceResult.textContent = "";
+      } else {
+        setupSection.classList.add("hidden");
+        gameSection.classList.remove("hidden");
+        renderScript();
+        renderPlayers();
+        updateCounts();
+        notesArea.value = state.notes;
+      }
+      renderAbilityTracker();
+      renderActionSummary();
+      renderDiceOptions();
+      renderDiceHistory();
+      renderDownloadLink();
+      clearNightTrackingButton.disabled = !state.players.some(player => player.targeted || player.protected);
+    }
+
+    playerCountInput.addEventListener("input", () => {
+      updatePlayerCountDisplays();
+      updateRoleSelectionUI();
+      persistState();
+    });
+
+    themeSelect.addEventListener("change", event => {
+      state.theme = event.target.value;
+      themeDescription.textContent = THEMES[state.theme].description;
+      persistState();
+      if (state.phase !== "setup") renderScript();
+    });
+
+    namesInput.addEventListener("input", () => {
+      state.nameList = namesInput.value;
+      persistState();
+    });
+
+    notesArea.addEventListener("input", event => {
+      state.notes = event.target.value;
+      persistState();
+      renderDownloadLink();
+    });
+
+    startButton.addEventListener("click", handleStartGame);
+    prevStepButton.addEventListener("click", goToPrevStep);
+    nextStepButton.addEventListener("click", goToNextStep);
+
+    timerButtons.forEach(btn => btn.addEventListener("click", () => startTimer(Number(btn.dataset.timer))));
+    startTimerBtn.addEventListener("click", () => startTimer());
+    pauseTimerBtn.addEventListener("click", pauseTimer);
+    resetTimerBtn.addEventListener("click", resetTimer);
+
+    clearNightTrackingButton.addEventListener("click", () => {
+      const hasMarkers = state.players.some(player => player.targeted || player.protected);
+      if (!hasMarkers) return;
+      if (!confirm("Clear all current night targets and protections?")) return;
+      state.players.forEach(player => {
+        player.targeted = false;
+        player.protected = false;
+      });
+      renderPlayers();
+      renderActionSummary();
+      persistState();
+      renderDownloadLink();
+      clearNightTrackingButton.disabled = true;
+    });
+
+    rollDiceButton.addEventListener("click", () => {
+      const selection = diceCharacterSelect.value;
+      if (!selection) {
+        alert("Select a sidekick or choose custom before rolling.");
+        return;
+      }
+
+      let playerId = null;
+      let label = "";
+      let role = "";
+
+      if (selection === "custom") {
+        const input = prompt("Label this roll (e.g., 'Practice roll' or character name).");
+        if (input === null) return;
+        label = input.trim() || "Custom";
+      } else {
+        playerId = Number(selection);
+        const player = state.players.find(p => p.id === playerId);
+        if (!player) {
+          alert("Selected player is no longer available.");
+          return;
+        }
+        label = player.name;
+        role = player.roleName;
+      }
+
+      const roll = Math.floor(Math.random() * 6) + 1;
+      const success = roll >= 4;
+      const entry = {
+        timestamp: Date.now(),
+        night: state.night,
+        playerId,
+        playerName: label,
+        roleName: role,
+        result: roll,
+        success
+      };
+      state.diceHistory = [entry, ...state.diceHistory].slice(0, 12);
+      persistState();
+      renderDiceHistory();
+      renderDownloadLink();
+    });
+
+    toggleModeButton.addEventListener("click", () => {
+      state.mode = state.mode === "light" ? "dark" : "light";
+      applyMode(state.mode);
+      persistState();
+    });
+
+    resetGameButton.addEventListener("click", () => {
+      if (confirm("Start a new game? Current progress will be cleared.")) {
+        resetState();
+      }
+    });
+
+    if ("serviceWorker" in navigator) {
+      window.addEventListener("load", () => {
+        navigator.serviceWorker.register("sw.js").catch(console.error);
+      });
+    }
+
+    renderThemeSelect();
+    renderRoleGroups();
+    updatePlayerCountDisplays();
+    updateRoleSelectionUI();
+    renderAll();
+  </script>
+</body>
+</html>

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,10 @@
+{
+  "name": "Melodrama Werewolf Narrator Tool",
+  "short_name": "Melodrama Narrator",
+  "description": "Guide night and day phases of the Melodrama Werewolf classroom game.",
+  "start_url": "./",
+  "display": "standalone",
+  "background_color": "#0f172a",
+  "theme_color": "#0f172a",
+  "icons": []
+}

--- a/sw.js
+++ b/sw.js
@@ -1,0 +1,28 @@
+const CACHE_NAME = 'melodrama-werewolf-v1';
+const ASSETS = [
+  './',
+  './index.html',
+  './manifest.json'
+];
+
+self.addEventListener('install', (event) => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then((cache) => cache.addAll(ASSETS))
+  );
+});
+
+self.addEventListener('activate', (event) => {
+  event.waitUntil(
+    caches.keys().then((keys) =>
+      Promise.all(
+        keys.filter((key) => key !== CACHE_NAME).map((key) => caches.delete(key))
+      )
+    )
+  );
+});
+
+self.addEventListener('fetch', (event) => {
+  event.respondWith(
+    caches.match(event.request).then((cached) => cached || fetch(event.request))
+  );
+});


### PR DESCRIPTION
## Summary
- add limited-ability tracker, night summary, and sidekick dice roller to the narrator dashboard
- extend client-side state to capture ability usage, targets/protections, and dice history with persistence and export support
- document the new classroom management tools in the feature list

## Testing
- not run (UI-only changes)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6916c3e5b0448332a8f42a3bc4eaad20)